### PR TITLE
[FEAT] 배송 담당자 주요 API 구현

### DIFF
--- a/src/main/java/com/tf4/delivery/DeliveryApplication.java
+++ b/src/main/java/com/tf4/delivery/DeliveryApplication.java
@@ -2,8 +2,10 @@ package com.tf4.delivery;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class DeliveryApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/tf4/delivery/controller/DeliveryAgentController.java
+++ b/src/main/java/com/tf4/delivery/controller/DeliveryAgentController.java
@@ -1,0 +1,65 @@
+package com.tf4.delivery.controller;
+
+
+import com.tf4.delivery.dto.request.DeliveryAgentCreateRequestDto;
+import com.tf4.delivery.dto.request.DeliveryAgentPatchRequestDto;
+import com.tf4.delivery.dto.response.DeliveryAgentCreateResponseDto;
+import com.tf4.delivery.dto.response.DeliveryAgentResponseDto;
+import com.tf4.delivery.dto.response.PageResponse;
+import com.tf4.delivery.service.DeliveryAgentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.math.BigInteger;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/deliveryAgents")
+@RequiredArgsConstructor
+public class DeliveryAgentController {
+
+    private final DeliveryAgentService deliveryAgentService;
+
+    // 배송 담당자 목록 조회 및 검색
+
+    @GetMapping
+    public ResponseEntity<PageResponse<DeliveryAgentResponseDto>> getDeliveries(
+            @PageableDefault(page = 0, size = 10, sort = "updatedAt", direction = Sort.Direction.DESC) Pageable pageable,
+            @RequestParam(value = "q", required = false) String q
+    ){
+        Page<DeliveryAgentResponseDto> page = deliveryAgentService.searchDeliveryAgents(q, pageable);
+        return ResponseEntity.ok(PageResponse.of(page));
+    }
+
+    // 배송 담당자 생성
+    @PostMapping
+    public ResponseEntity<DeliveryAgentCreateResponseDto> createDelivery(
+            @Validated
+            @RequestBody DeliveryAgentCreateRequestDto requestDto){
+        return new ResponseEntity<>(deliveryAgentService.createDeliveryAgent(requestDto), HttpStatus.CREATED);
+    }
+
+    // 배송 담당자 수정
+    @PatchMapping("/{deliveryAgentId}")
+    public ResponseEntity<DeliveryAgentResponseDto> patchDeliveryAgent (
+            @PathVariable BigInteger userId,
+            @Validated
+            @RequestBody DeliveryAgentPatchRequestDto requestDto){
+        return new ResponseEntity<>(deliveryAgentService.patchDeliveryAgent(userId, requestDto), HttpStatus.OK);
+    }
+    // 배송 삭제
+    @DeleteMapping("/{deliveryAgentId}")
+    public ResponseEntity<Void> deleteDeliveryAgent(@PathVariable BigInteger userId){
+        deliveryAgentService.deleteDeliveryAgent(userId);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+
+
+}

--- a/src/main/java/com/tf4/delivery/controller/DeliveryAgentController.java
+++ b/src/main/java/com/tf4/delivery/controller/DeliveryAgentController.java
@@ -18,7 +18,6 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.math.BigInteger;
-import java.util.UUID;
 
 @RestController
 @RequestMapping("/deliveryAgents")
@@ -28,9 +27,8 @@ public class DeliveryAgentController {
     private final DeliveryAgentService deliveryAgentService;
 
     // 배송 담당자 목록 조회 및 검색
-
     @GetMapping
-    public ResponseEntity<PageResponse<DeliveryAgentResponseDto>> getDeliveries(
+    public ResponseEntity<PageResponse<DeliveryAgentResponseDto>> getDeliveryAgent(
             @PageableDefault(page = 0, size = 10, sort = "updatedAt", direction = Sort.Direction.DESC) Pageable pageable,
             @RequestParam(value = "q", required = false) String q
     ){
@@ -38,9 +36,15 @@ public class DeliveryAgentController {
         return ResponseEntity.ok(PageResponse.of(page));
     }
 
+    // 배송 담당자 단 건 조회
+    @GetMapping("/{deliveryAgentId}")
+    public ResponseEntity<DeliveryAgentResponseDto> getDeliveryAgent (@PathVariable BigInteger deliveryAgentId){
+        return new ResponseEntity<>(deliveryAgentService.getDeliveryAgent(deliveryAgentId), HttpStatus.OK);
+    }
+
     // 배송 담당자 생성
     @PostMapping
-    public ResponseEntity<DeliveryAgentCreateResponseDto> createDelivery(
+    public ResponseEntity<DeliveryAgentCreateResponseDto> createDeliveryAgent(
             @Validated
             @RequestBody DeliveryAgentCreateRequestDto requestDto){
         return new ResponseEntity<>(deliveryAgentService.createDeliveryAgent(requestDto), HttpStatus.CREATED);
@@ -49,17 +53,16 @@ public class DeliveryAgentController {
     // 배송 담당자 수정
     @PatchMapping("/{deliveryAgentId}")
     public ResponseEntity<DeliveryAgentResponseDto> patchDeliveryAgent (
-            @PathVariable BigInteger userId,
+            @PathVariable BigInteger deliveryAgentId,
             @Validated
             @RequestBody DeliveryAgentPatchRequestDto requestDto){
-        return new ResponseEntity<>(deliveryAgentService.patchDeliveryAgent(userId, requestDto), HttpStatus.OK);
+        return new ResponseEntity<>(deliveryAgentService.patchDeliveryAgent(deliveryAgentId, requestDto), HttpStatus.OK);
     }
     // 배송 삭제
     @DeleteMapping("/{deliveryAgentId}")
-    public ResponseEntity<Void> deleteDeliveryAgent(@PathVariable BigInteger userId){
-        deliveryAgentService.deleteDeliveryAgent(userId);
+    public ResponseEntity<Void> deleteDeliveryAgent(@PathVariable BigInteger deliveryAgentId){
+        deliveryAgentService.deleteDeliveryAgent(deliveryAgentId);
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
-
 
 }

--- a/src/main/java/com/tf4/delivery/dto/request/DeliveryAgentCreateRequestDto.java
+++ b/src/main/java/com/tf4/delivery/dto/request/DeliveryAgentCreateRequestDto.java
@@ -1,0 +1,13 @@
+package com.tf4.delivery.dto.request;
+
+import lombok.Getter;
+
+import java.math.BigInteger;
+import java.util.UUID;
+
+@Getter
+public class DeliveryAgentCreateRequestDto {
+    private String deliveryType;
+    private UUID hubId;
+    private BigInteger userId;
+}

--- a/src/main/java/com/tf4/delivery/dto/request/DeliveryAgentPatchRequestDto.java
+++ b/src/main/java/com/tf4/delivery/dto/request/DeliveryAgentPatchRequestDto.java
@@ -1,0 +1,14 @@
+package com.tf4.delivery.dto.request;
+
+import jakarta.persistence.Column;
+import lombok.Getter;
+
+import java.math.BigInteger;
+import java.util.UUID;
+
+@Getter
+public class DeliveryAgentPatchRequestDto {
+    private String deliveryType;
+    private BigInteger userId;
+    private UUID hubId;
+}

--- a/src/main/java/com/tf4/delivery/dto/response/DeliveryAgentCreateResponseDto.java
+++ b/src/main/java/com/tf4/delivery/dto/response/DeliveryAgentCreateResponseDto.java
@@ -1,0 +1,12 @@
+package com.tf4.delivery.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.math.BigInteger;
+
+@Getter
+@AllArgsConstructor
+public class DeliveryAgentCreateResponseDto {
+    private BigInteger userId;
+}

--- a/src/main/java/com/tf4/delivery/dto/response/DeliveryAgentResponseDto.java
+++ b/src/main/java/com/tf4/delivery/dto/response/DeliveryAgentResponseDto.java
@@ -1,0 +1,34 @@
+package com.tf4.delivery.dto.response;
+
+import com.tf4.delivery.entity.DeliveryAgent;
+import jakarta.persistence.Column;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigInteger;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class DeliveryAgentResponseDto {
+    private BigInteger userId;
+    private String deliveryType;
+    private BigInteger deliverySeq;
+    private UUID hubId;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public static DeliveryAgentResponseDto from(DeliveryAgent d) {
+        return DeliveryAgentResponseDto.builder()
+                .userId(d.getUserId())
+                .deliveryType(d.getDeliveryType())
+                .deliverySeq(d.getDeliverySeq())
+                .hubId(d.getHubId())
+                .createdAt(d.getCreatedAt())
+                .updatedAt(d.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/tf4/delivery/dto/response/PageResponse.java
+++ b/src/main/java/com/tf4/delivery/dto/response/PageResponse.java
@@ -1,0 +1,40 @@
+package com.tf4.delivery.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class PageResponse<T> {
+    private List<T> data;
+    private int page;
+    private int size;
+    private long totalElements;
+    private int totalPages;
+    private String sort;
+
+    public static <T> PageResponse<T> of(Page<T> page) {
+        String sortParam = page.getPageable().getSort().stream()
+                .map(order -> order.getProperty() + "," + order.getDirection().name().toLowerCase())
+                .findFirst()
+                .orElse("createdAt,desc");
+        /*
+         * order.getProperty() → 어떤 컬럼으로 정렬했는지 (예: "createdAt")
+         * order.getDirection().name().toLowerCase() → 정렬 방향 (예: "desc")
+         * 합쳐서 "createdAt,desc" 같은 문자열을 생성.
+         * 만약 정렬 조건이 비어있다면 기본 "createdAt,desc"로 대체.
+         * */
+
+        return new PageResponse<>(
+                page.getContent(),
+                page.getNumber() + 1,   // PageRequest는 0-based, 요구사항은 1-based
+                page.getSize(),
+                page.getTotalElements(),
+                page.getTotalPages(),
+                sortParam
+        );
+    }
+}

--- a/src/main/java/com/tf4/delivery/entity/DeliveryAgent.java
+++ b/src/main/java/com/tf4/delivery/entity/DeliveryAgent.java
@@ -1,0 +1,41 @@
+package com.tf4.delivery.entity;
+
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.math.BigInteger;
+import java.util.UUID;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@Table(name = "p_delivery_agent")
+public class DeliveryAgent extends Timestamped {
+
+    @Id
+    @Column(name = "user_id")
+    private BigInteger userId;
+
+    @Column(name = "delivery_type", length = 50) // VARCHAR(50)
+    private String deliveryType;
+
+    @Column(name = "delivery_seq")
+    private BigInteger deliverySeq;
+
+    @Column(name = "hub_id")
+    private UUID hubId;
+
+
+    @Builder
+    public DeliveryAgent(BigInteger userId, String deliveryType, BigInteger deliverySeq, UUID hubId) {
+        this.userId = userId;
+        this.deliveryType = deliveryType;
+        this.deliverySeq = deliverySeq;
+        this.hubId = hubId;
+    }
+}

--- a/src/main/java/com/tf4/delivery/entity/Timestamped.java
+++ b/src/main/java/com/tf4/delivery/entity/Timestamped.java
@@ -1,0 +1,48 @@
+package com.tf4.delivery.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class Timestamped {
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false, nullable = false)
+    protected LocalDateTime createdAt;
+
+    @CreatedBy
+    @Column(name = "created_by", updatable = false, nullable = false)
+    protected UUID createdBy;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    protected LocalDateTime updatedAt;
+
+    @LastModifiedBy
+    @Column(name = "updated_by", nullable = false)
+    protected UUID updatedBy;
+
+    @Column(name = "deleted_at")
+    protected LocalDateTime deletedAt;
+
+    @Column(name = "deleted_by")
+    protected UUID deletedBy;
+
+    /* 소프트 삭제 메서드 */
+    public void delete(UUID userId) {
+        this.deletedAt = LocalDateTime.now();
+        this.deletedBy = userId;
+    }
+}

--- a/src/main/java/com/tf4/delivery/repository/DeliveryAgentRepository.java
+++ b/src/main/java/com/tf4/delivery/repository/DeliveryAgentRepository.java
@@ -1,0 +1,12 @@
+package com.tf4.delivery.repository;
+
+import com.tf4.delivery.entity.DeliveryAgent;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+
+import java.math.BigInteger;
+
+public interface DeliveryAgentRepository extends JpaRepository<DeliveryAgent, BigInteger>,
+        JpaSpecificationExecutor<DeliveryAgent> {
+    DeliveryAgent save(DeliveryAgent deliveryAgent);
+}

--- a/src/main/java/com/tf4/delivery/repository/DeliveryAgentRepository.java
+++ b/src/main/java/com/tf4/delivery/repository/DeliveryAgentRepository.java
@@ -3,10 +3,22 @@ package com.tf4.delivery.repository;
 import com.tf4.delivery.entity.DeliveryAgent;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.math.BigInteger;
+import java.util.Optional;
+import java.util.UUID;
 
 public interface DeliveryAgentRepository extends JpaRepository<DeliveryAgent, BigInteger>,
         JpaSpecificationExecutor<DeliveryAgent> {
+
     DeliveryAgent save(DeliveryAgent deliveryAgent);
+
+    Optional<DeliveryAgent> findFirstByDeliveryTypeAndDeletedAtIsNullOrderByDeliverySeqDesc(String DeliveryType);
+    Optional<DeliveryAgent>
+    findFirstByDeliveryTypeAndHubIdAndDeletedAtIsNullOrderByDeliverySeqDesc(String DeliveryType, UUID hubId);
+
+
+
 }

--- a/src/main/java/com/tf4/delivery/service/DeliveryAgentService.java
+++ b/src/main/java/com/tf4/delivery/service/DeliveryAgentService.java
@@ -9,6 +9,7 @@ import com.tf4.delivery.repository.DeliveryAgentRepository;
 import com.tf4.delivery.spec.DeliveryAgentSpecifications;
 import jakarta.ws.rs.NotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.aspectj.weaver.loadtime.Agent;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -38,14 +39,41 @@ public class DeliveryAgentService {
         return deliveryAgentRepository.findAll(spec, capped).map(DeliveryAgentResponseDto::from);
     }
 
+    public DeliveryAgentResponseDto getDeliveryAgent(BigInteger userId){
+        DeliveryAgent deliveryAgent = deliveryAgentRepository.findById(userId)
+                .orElseThrow(() -> new NotFoundException("배송 담당자를 찾을 수 없습니다. "));
+        return DeliveryAgentResponseDto.from(deliveryAgent);
+    }
+
     @Transactional
     public DeliveryAgentCreateResponseDto createDeliveryAgent(DeliveryAgentCreateRequestDto requestDto){
         // 사용자 권한에 따라 다르게 해줘야함
+
+        // userId가 Deliver인 상태면 생성가능
+        // 타입이 허브면 삭제된거 빼고 젤큰 배송 순번 +1
+        // 타입이 업체면 소속 허브 Id중 젤큰 배송 순번 +1
+        String agentType = requestDto.getDeliveryType();
+        BigInteger deliverySeq = BigInteger.ZERO;
+        if(agentType.equals("HUB")){
+            DeliveryAgent deliveryAgent =
+                    deliveryAgentRepository.findFirstByDeliveryTypeAndDeletedAtIsNullOrderByDeliverySeqDesc("HUB")
+                    .orElseThrow(() -> new NotFoundException("배정가능한 배송 담당자가 없습니다."));
+
+            deliverySeq = deliveryAgent.getDeliverySeq();
+        } else if(agentType.equals("COMPANY")){
+            DeliveryAgent deliveryAgent =
+                    deliveryAgentRepository.findFirstByDeliveryTypeAndHubIdAndDeletedAtIsNullOrderByDeliverySeqDesc(
+                            "COMPANY",
+                            requestDto.getHubId())
+                    .orElseThrow(() -> new NotFoundException("배정가능한 배송 담당자가 없습니다."));
+            deliverySeq = deliveryAgent.getDeliverySeq();
+        }
+
         DeliveryAgent deliveryAgent = DeliveryAgent.builder()
                 .deliveryType(requestDto.getDeliveryType())
                 .hubId(requestDto.getHubId())
                 .userId(requestDto.getUserId())
-                .deliverySeq(BigInteger.ONE) // tmp 순서 지정해주는 함수 만들예정
+                .deliverySeq(deliverySeq.add(BigInteger.ONE))
                 .build();
 
         DeliveryAgent savedDeliveryAgent = deliveryAgentRepository.save(deliveryAgent);

--- a/src/main/java/com/tf4/delivery/service/DeliveryAgentService.java
+++ b/src/main/java/com/tf4/delivery/service/DeliveryAgentService.java
@@ -1,0 +1,94 @@
+package com.tf4.delivery.service;
+
+import com.tf4.delivery.dto.request.DeliveryAgentCreateRequestDto;
+import com.tf4.delivery.dto.request.DeliveryAgentPatchRequestDto;
+import com.tf4.delivery.dto.response.DeliveryAgentCreateResponseDto;
+import com.tf4.delivery.dto.response.DeliveryAgentResponseDto;
+import com.tf4.delivery.entity.DeliveryAgent;
+import com.tf4.delivery.repository.DeliveryAgentRepository;
+import com.tf4.delivery.spec.DeliveryAgentSpecifications;
+import jakarta.ws.rs.NotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigInteger;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class DeliveryAgentService {
+
+    private final DeliveryAgentRepository deliveryAgentRepository;
+
+    public Page<DeliveryAgentResponseDto> searchDeliveryAgents(String q, Pageable pageable){
+
+        Pageable capped = PageRequest.of(
+                pageable.getPageNumber(),
+                Math.min(pageable.getPageSize(), 100),
+                pageable.getSort()
+        );
+
+        Specification<DeliveryAgent> spec = DeliveryAgentSpecifications.searchAllFields(q);
+
+        return deliveryAgentRepository.findAll(spec, capped).map(DeliveryAgentResponseDto::from);
+    }
+
+    @Transactional
+    public DeliveryAgentCreateResponseDto createDeliveryAgent(DeliveryAgentCreateRequestDto requestDto){
+        // 사용자 권한에 따라 다르게 해줘야함
+        DeliveryAgent deliveryAgent = DeliveryAgent.builder()
+                .deliveryType(requestDto.getDeliveryType())
+                .hubId(requestDto.getHubId())
+                .userId(requestDto.getUserId())
+                .deliverySeq(BigInteger.ONE) // tmp 순서 지정해주는 함수 만들예정
+                .build();
+
+        DeliveryAgent savedDeliveryAgent = deliveryAgentRepository.save(deliveryAgent);
+        return new DeliveryAgentCreateResponseDto(savedDeliveryAgent.getUserId());
+    }
+
+    @Transactional
+    public DeliveryAgentResponseDto patchDeliveryAgent(BigInteger userId, DeliveryAgentPatchRequestDto requestDto) {
+        DeliveryAgent deliveryAgent = deliveryAgentRepository.findById(userId)
+                .orElseThrow(() -> new NotFoundException("배송 담당자를 찾을 수 없습니다."));
+
+        // 현재 맡고 있는 배송이 배송중인 경우 수정 불가
+        // p_delivery_route_legs에서 현재상태가 WAIT_AT_HUB가 아닌 것들 중에 userId가 포함 되는 배송이 있으면
+        // 수정 불가 안내하기 -> 추후 작성 예정
+
+        // 배송 타입
+        if (requestDto.getDeliveryType() != null) {
+            //ensureHubExists(requestDto.getDepartureHubId());           // 없으면 404/422 던지기
+            deliveryAgent.setDeliveryType(requestDto.getDeliveryType());
+        }
+        // 소속 허브 Id
+        if (requestDto.getHubId() != null) {
+            //ensureHubExists(requestDto.getArrivalHubId());
+            deliveryAgent.setHubId(requestDto.getHubId());
+        }
+        // 배송 담당 user Id
+        if (requestDto.getUserId() != null) {
+            deliveryAgent.setUserId(requestDto.getUserId());
+        }
+
+        return DeliveryAgentResponseDto.from(deliveryAgent);
+    }
+
+    @Transactional
+    public void deleteDeliveryAgent(BigInteger userId){
+        DeliveryAgent deliveryAgent = deliveryAgentRepository.findById(userId)
+                .orElseThrow(() -> new NotFoundException("배송담당자를 찾을 수 없습니다. "));
+
+        if (deliveryAgent.getDeletedAt() != null) return;
+
+        // 지운자가 누군지 값이 필요함
+        // 추후 수정 필요함
+        UUID actorId = UUID.randomUUID();
+        deliveryAgent.delete(actorId);
+    }
+}

--- a/src/main/java/com/tf4/delivery/spec/DeliveryAgentSpecifications.java
+++ b/src/main/java/com/tf4/delivery/spec/DeliveryAgentSpecifications.java
@@ -1,0 +1,62 @@
+package com.tf4.delivery.spec;
+
+import com.tf4.delivery.entity.DeliveryAgent;
+import jakarta.persistence.criteria.Expression;
+import jakarta.persistence.criteria.Predicate;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public class DeliveryAgentSpecifications {
+
+    private DeliveryAgentSpecifications() {}
+
+    public static Specification<DeliveryAgent> searchAllFields(String q) {
+        return (root, query, cb) -> {
+            // q가 비어있으면 항상 true 반환
+            if (q == null || q.isBlank()) return cb.conjunction();
+
+            final String qTrim = q.trim();
+            final String like = "%" + qTrim.toLowerCase() + "%";
+
+            List<Predicate> orList = new ArrayList<>();
+
+            // 문자열 컬럼 부분일치 (대소문자 무시)
+            orList.add(cb.like(cb.lower(root.get("deliveryType")), like));
+
+
+            // 숫자(정확 매치) — 수령인/담당자 등 정수 컬럼
+            if (qTrim.chars().allMatch(Character::isDigit)) {
+                try {
+                    long n = Long.parseLong(qTrim);
+                    orList.add(cb.equal(root.get("userId"), n));
+                    orList.add(cb.equal(root.get("deliverySeq"), n));
+                } catch (NumberFormatException ignore) {}
+            }
+
+            // UUID 정확 매치(인덱스 활용)
+            tryParseUuid(qTrim).ifPresent(uuid -> {
+                orList.add(cb.equal(root.get("hubId"), uuid));
+            });
+
+            // UUID 문자열 LIKE (보조; 인덱스 못 탐 → 과도한 사용 주의)
+            Expression<String> hubId = cb.lower(cb.toString(root.get("hubId")));
+            orList.add(cb.like(hubId, like));
+
+            // (선택) 너무 짧은 검색어(예: 1자)는 폭검색 방지
+            // if (qTrim.length() < 2 && tryParseUuid(qTrim).isEmpty() && !qTrim.chars().allMatch(Character::isDigit)) {
+            //     return cb.disjunction(); // 결과 0건. 필요 시 400 에러로 바꿔도 됨.
+            // }
+
+            return cb.or(orList.toArray(new Predicate[0]));
+        };
+    }
+
+    private static Optional<UUID> tryParseUuid(String s) {
+        try { return Optional.of(UUID.fromString(s)); }
+        catch (Exception e) { return Optional.empty(); }
+    }
+}

--- a/src/main/java/com/tf4/delivery/spec/DeliveryAgentSpecifications.java
+++ b/src/main/java/com/tf4/delivery/spec/DeliveryAgentSpecifications.java
@@ -17,7 +17,11 @@ public class DeliveryAgentSpecifications {
     public static Specification<DeliveryAgent> searchAllFields(String q) {
         return (root, query, cb) -> {
             // q가 비어있으면 항상 true 반환
-            if (q == null || q.isBlank()) return cb.conjunction();
+            Predicate notDeleted = cb.isNull(root.get("deletedAt"));
+
+            if (q == null || q.isBlank()) {
+                return notDeleted; // 전체 조회도 삭제건 제외
+            }
 
             final String qTrim = q.trim();
             final String like = "%" + qTrim.toLowerCase() + "%";
@@ -51,7 +55,7 @@ public class DeliveryAgentSpecifications {
             //     return cb.disjunction(); // 결과 0건. 필요 시 400 에러로 바꿔도 됨.
             // }
 
-            return cb.or(orList.toArray(new Predicate[0]));
+            return cb.and(notDeleted, cb.or(orList.toArray(new Predicate[0])));
         };
     }
 


### PR DESCRIPTION
## 작업 내용

- 배송 담당자 목록 조회 API: Pageable 자동 바인딩(page/size/sort) + PageResponse 포맷, q 전역 검색 지원
- 배송 담당자 생성 API: CreateRequest/Response DTO 기반, @Transactional 서비스 구현
- 배송 담당자 부분 수정 API(PATCH /delivery-agents/{id}): null 아닌 필드만 갱신, 더티체킹 반영
- 배송 담당자 삭제 API: 204 No Content 반환(소프트 삭제 기반)
- 전역 검색 스펙: PostgreSQL ILIKE 다중 컬럼 OR, UUID 정확 매치/보조 LIKE, 숫자 필드 매치
- 공통: JPA Auditing 활성화, Timestamped(작성/수정자·시각, soft delete), JpaSpecificationExecutor 적용, PageResponse 공용 DTO 추가

## 관련 이슈
추후 이슈 연동 예정

## 작업 상세 내용

- DeliveryAgent.java: 배송 담당자 엔티티 정의(UUID PK, 핵심 컬럼 제약), Timestamped 상속
- DeliveryAgentController.java:
  - GET /delivery-agents 페이징 조회(자동 바인딩, q 검색)
  - POST /delivery-agents 생성
  - PATCH /delivery-agents/{id} 부분 수정
  - DELETE /delivery-agents/{id} 204 No Content 응답
- DeliveryAgentCreateRequestDto.java / DeliveryAgentPatchRequestDto.java / DeliveryAgentResponseDto.java: 생성/부분수정/응답 DTO 정의 및 from 매핑
- DeliveryAgentRepository.java: JpaRepository + JpaSpecificationExecutor 적용(동적 검색)
- DeliveryAgentSpecifications.java: q 기반 다중 컬럼 OR 검색(ILIKE, UUID/숫자 매칭)
- DeliveryAgentService.java: 검색/전체 조회/생성/부분 수정/삭제 서비스 구현(@Transactional), 페이지 사이즈 상한 적용(≤100)
- DeliveryApplication.java: JPA Auditing 활성화
- PageResponse.java: Page → API 스펙(data/page/size/total/sort) 변환 공용 DTO
- Timestamped.java: 생성·수정 시각/작성자 및 소프트 삭제 필드·메서드 제공

## 주의사항

추후 수정이 필요한 부분들이 있는데, 그 부분은 정리되는대로 반영하겠습니다.
주석들이 좀 남아있는데 수정 필요한 부분 마무리 되는대로 제거하겠습니다.