### PR TITLE
[FEAT] 주요 배송 로직 추가(허브간 배송 경로 기록) 및 버그 수정

### DIFF
--- a/src/main/java/com/tf4/delivery/common/event/DeliveryCreatedEvent.java
+++ b/src/main/java/com/tf4/delivery/common/event/DeliveryCreatedEvent.java
@@ -1,0 +1,31 @@
+package com.tf4.delivery.common.event;
+
+import com.tf4.delivery.entity.Delivery;
+
+import java.util.Objects;
+import java.util.UUID;
+
+public class DeliveryCreatedEvent {
+
+    private final UUID deliveryId;
+    private final UUID departureHubId;
+    private final UUID arrivalHubId;
+
+    public DeliveryCreatedEvent(UUID deliveryId, UUID departureHubId, UUID arrivalHubId) {
+        this.deliveryId = Objects.requireNonNull(deliveryId, "deliveryId");
+        this.departureHubId = Objects.requireNonNull(departureHubId, "departureHubId");
+        this.arrivalHubId = Objects.requireNonNull(arrivalHubId, "arrivalHubId");
+    }
+
+    public static DeliveryCreatedEvent of(Delivery d) {
+        return new DeliveryCreatedEvent(
+                d.getDeliveryId(),
+                d.getDepartureHubId(),
+                d.getArrivalHubId()
+        );
+    }
+
+    public UUID getDeliveryId() { return deliveryId; }
+    public UUID getDepartureHubId() { return departureHubId; }
+    public UUID getArrivalHubId() { return arrivalHubId; }
+}

--- a/src/main/java/com/tf4/delivery/controller/DeliveryController.java
+++ b/src/main/java/com/tf4/delivery/controller/DeliveryController.java
@@ -11,11 +11,13 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
 import java.util.UUID;
 
 @RestController
@@ -28,10 +30,14 @@ public class DeliveryController {
     // 배송 목록 조회 및 검색
     @GetMapping
     public ResponseEntity<PageResponse<DeliveryResponseDto>> getDeliveries(
-            @PageableDefault(page = 0, size = 10, sort = "updatedAt", direction = Sort.Direction.DESC)Pageable pageable,
-            @RequestParam(value = "q", required = false) String q
+            @PageableDefault(page = 0, size = 10, sort = "updatedAt", direction = Sort.Direction.DESC)
+                    Pageable pageable,
+            @RequestParam(value = "q", required = false) String q,
+            @RequestParam(value = "status", required = false) String status,
+            @RequestParam(value = "date", required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date // yyyy-MM-dd
     ){
-        Page<DeliveryResponseDto> page = deliveryService.searchDeliveries(q, pageable);
+        Page<DeliveryResponseDto> page = deliveryService.searchDeliveries(q, status, date, pageable);
         return ResponseEntity.ok(PageResponse.of(page));
     }
 

--- a/src/main/java/com/tf4/delivery/dto/request/DeliveryPatchRequestDto.java
+++ b/src/main/java/com/tf4/delivery/dto/request/DeliveryPatchRequestDto.java
@@ -1,10 +1,12 @@
 package com.tf4.delivery.dto.request;
 
+import lombok.Builder;
 import lombok.Getter;
 
 import java.util.UUID;
 
 @Getter
+@Builder
 public class DeliveryPatchRequestDto {
     private String status;
     private UUID departureHubId;

--- a/src/main/java/com/tf4/delivery/dto/request/DeliveryRouteLegCreateRequestDto.java
+++ b/src/main/java/com/tf4/delivery/dto/request/DeliveryRouteLegCreateRequestDto.java
@@ -1,21 +1,19 @@
 package com.tf4.delivery.dto.request;
 
+import com.tf4.delivery.dto.response.DeliveryRouteLegResponseDto;
+import com.tf4.delivery.entity.DeliveryRouteLeg;
+import lombok.Builder;
 import lombok.Getter;
 
 import java.util.UUID;
 
 @Getter
+@Builder
 public class DeliveryRouteLegCreateRequestDto {
-
-    private UUID routeLegId;
+//
+//    private UUID routeLegId;
     private UUID deliveryId;
     private UUID departureHubId;
     private UUID arrivalHubId;
-    private Double estimatedDistanceKm;
-    private Double estimatedTimeMin;
-    private Double actualDistanceKm;
-    private Double actualTimeMin;
-    private String status;
-    private UUID hubDeliveryAgentId;
 
 }

--- a/src/main/java/com/tf4/delivery/dto/request/DeliveryRouteLegPatchRequestDto.java
+++ b/src/main/java/com/tf4/delivery/dto/request/DeliveryRouteLegPatchRequestDto.java
@@ -11,9 +11,9 @@ public class DeliveryRouteLegPatchRequestDto {
     private UUID departureHubId;
     private UUID arrivalHubId;
     private Double estimatedDistanceKm;
-    private Double estimatedTimeMin;
+    private Long estimatedTimeMin;
     private Double actualDistanceKm;
-    private Double actualTimeMin;
+    private Long actualTimeMin;
     private String status;
     private UUID hubDeliveryAgentId;
 }

--- a/src/main/java/com/tf4/delivery/dto/response/DeliveryRouteLegResponseDto.java
+++ b/src/main/java/com/tf4/delivery/dto/response/DeliveryRouteLegResponseDto.java
@@ -17,9 +17,9 @@ public class DeliveryRouteLegResponseDto {
     private UUID departureHubId;
     private UUID arrivalHubId;
     private Double estimatedDistanceKm;
-    private Double estimatedTimeMin;
+    private Long estimatedTimeMin;
     private Double actualDistanceKm;
-    private Double actualTimeMin;
+    private Long actualTimeMin;
     private String status;
     private UUID hubDeliveryAgentId;
     private LocalDateTime createdAt;

--- a/src/main/java/com/tf4/delivery/dto/response/LogisticsManageResponseDto.java
+++ b/src/main/java/com/tf4/delivery/dto/response/LogisticsManageResponseDto.java
@@ -1,0 +1,12 @@
+package com.tf4.delivery.dto.response;
+
+import com.tf4.delivery.entity.DeliveryRouteLeg;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class LogisticsManageResponseDto {
+    private final Long id;
+    private final Long currentSequence;
+}

--- a/src/main/java/com/tf4/delivery/entity/DeliveryRouteLeg.java
+++ b/src/main/java/com/tf4/delivery/entity/DeliveryRouteLeg.java
@@ -33,13 +33,13 @@ public class DeliveryRouteLeg extends Timestamped{
     private Double estimatedDistanceKm;
 
     @Column(name = "estimated_time_min", nullable = false)
-    private Double estimatedTimeMin;
+    private Long estimatedTimeMin;
 
     @Column(name = "actual_distance_km")
     private Double actualDistanceKm;
 
     @Column(name = "actual_time_min")
-    private Double actualTimeMin;
+    private Long actualTimeMin;
 
     @Column(name = "status", nullable = false, length = 100) // VARCHAR(100)
     private String status;
@@ -49,8 +49,8 @@ public class DeliveryRouteLeg extends Timestamped{
 
     @Builder
     public DeliveryRouteLeg(UUID routeLegId, UUID deliveryId, UUID departureHubId, UUID arrivalHubId,
-                            Double estimatedDistanceKm, Double estimatedTimeMin, Double actualDistanceKm,
-                            Double actualTimeMin, String status, UUID hubDeliveryAgentId) {
+                            Double estimatedDistanceKm, Long estimatedTimeMin, Double actualDistanceKm,
+                            Long actualTimeMin, String status, UUID hubDeliveryAgentId) {
 
         this.routeLegId = routeLegId;
         this.deliveryId = deliveryId;

--- a/src/main/java/com/tf4/delivery/entity/LogisticsManage.java
+++ b/src/main/java/com/tf4/delivery/entity/LogisticsManage.java
@@ -1,0 +1,31 @@
+package com.tf4.delivery.entity;
+
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.math.BigInteger;
+
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@Table(name = "p_logistics_manages")
+public class LogisticsManage extends Timestamped {
+    @Id
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "current_agent_seq", nullable = false)
+    private BigInteger currentAgentSeq;
+
+    @Builder
+    public LogisticsManage(Long id, BigInteger currentAgentSeq) {
+        this.id = id;
+        this.currentAgentSeq = currentAgentSeq;
+    }
+}

--- a/src/main/java/com/tf4/delivery/repository/feign/hub/HubFeignClient.java
+++ b/src/main/java/com/tf4/delivery/repository/feign/hub/HubFeignClient.java
@@ -1,0 +1,28 @@
+package com.tf4.delivery.repository.feign.hub;
+
+import com.tf4.delivery.repository.feign.hub.response.HubFindInfoResponseDto;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.UUID;
+
+@FeignClient(
+        name = "hub",
+        url = "localhost:3340",
+        path = "/hub-routes",
+        fallbackFactory = HubFeignFallbackFactory.class)
+public interface HubFeignClient {
+
+    @GetMapping("/{userId}")
+    HubFindInfoResponseDto findHubInfoByUserId(@PathVariable("userId") UUID userId);
+
+    @GetMapping("/{hubId}")
+    HubFindInfoResponseDto findHubInfoByHubId(@PathVariable("hubId") UUID hubId);
+
+    @GetMapping()
+    HubFindInfoResponseDto findHubIDByHubId(@RequestParam("from") UUID departureHubId,
+                                              @RequestParam("to") UUID arrivalHubId);
+}
+

--- a/src/main/java/com/tf4/delivery/repository/feign/hub/HubFeignFallbackFactory.java
+++ b/src/main/java/com/tf4/delivery/repository/feign/hub/HubFeignFallbackFactory.java
@@ -1,0 +1,13 @@
+package com.tf4.delivery.repository.feign.hub;
+
+import org.springframework.cloud.openfeign.FallbackFactory;
+import org.springframework.stereotype.Component;
+
+@Component
+public class HubFeignFallbackFactory implements FallbackFactory<HubFeignClient> {
+
+    @Override
+    public HubFeignClient create(Throwable cause) {
+        return null;
+    }
+}

--- a/src/main/java/com/tf4/delivery/repository/feign/hub/response/HubFindInfoResponseDto.java
+++ b/src/main/java/com/tf4/delivery/repository/feign/hub/response/HubFindInfoResponseDto.java
@@ -1,0 +1,16 @@
+package com.tf4.delivery.repository.feign.hub.response;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.UUID;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class HubFindInfoResponseDto{
+        UUID hubId;
+        Long transitTime;
+        Double distance;
+}

--- a/src/main/java/com/tf4/delivery/repository/jpa/DeliveryAgentRepository.java
+++ b/src/main/java/com/tf4/delivery/repository/jpa/DeliveryAgentRepository.java
@@ -1,9 +1,12 @@
-package com.tf4.delivery.repository;
+package com.tf4.delivery.repository.jpa;
 
 import com.tf4.delivery.entity.DeliveryAgent;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Lock;
 
+import java.math.BigInteger;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -16,6 +19,14 @@ public interface DeliveryAgentRepository extends JpaRepository<DeliveryAgent, UU
     Optional<DeliveryAgent>
     findFirstByDeliveryTypeAndHubIdAndDeletedAtIsNullOrderByDeliverySeqDesc(String DeliveryType, UUID hubId);
 
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    Optional<DeliveryAgent> findFirstByDeliveryTypeAndDeletedAtIsNullAndDeliverySeqGreaterThanOrderByDeliverySeqAsc(
+            String DeliveryType, BigInteger seq);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    Optional<DeliveryAgent> findFirstByDeliveryTypeAndDeletedAtIsNullOrderByDeliverySeqAsc(
+            String DeliveryType);
 
 
 }

--- a/src/main/java/com/tf4/delivery/repository/jpa/LogisticsManageRepository.java
+++ b/src/main/java/com/tf4/delivery/repository/jpa/LogisticsManageRepository.java
@@ -1,0 +1,23 @@
+package com.tf4.delivery.repository.jpa;
+
+import com.tf4.delivery.entity.LogisticsManage;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface LogisticsManageRepository extends JpaRepository<LogisticsManage, Long>,
+        JpaSpecificationExecutor<LogisticsManage>{
+    LogisticsManage save(LogisticsManage logisticsManage);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select lm from LogisticsManage lm where lm.id = :id")
+    Optional<LogisticsManage> lockById(@Param("id") Long id);
+
+}

--- a/src/main/java/com/tf4/delivery/service/DeliveryAgentService.java
+++ b/src/main/java/com/tf4/delivery/service/DeliveryAgentService.java
@@ -5,7 +5,7 @@ import com.tf4.delivery.dto.request.DeliveryAgentPatchRequestDto;
 import com.tf4.delivery.dto.response.DeliveryAgentCreateResponseDto;
 import com.tf4.delivery.dto.response.DeliveryAgentResponseDto;
 import com.tf4.delivery.entity.DeliveryAgent;
-import com.tf4.delivery.repository.DeliveryAgentRepository;
+import com.tf4.delivery.repository.jpa.DeliveryAgentRepository;
 import com.tf4.delivery.spec.DeliveryAgentSpecifications;
 import jakarta.ws.rs.NotFoundException;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/tf4/delivery/service/DeliveryRouteLegService.java
+++ b/src/main/java/com/tf4/delivery/service/DeliveryRouteLegService.java
@@ -1,11 +1,21 @@
 package com.tf4.delivery.service;
 
+import com.tf4.delivery.dto.request.DeliveryPatchRequestDto;
 import com.tf4.delivery.dto.request.DeliveryRouteLegCreateRequestDto;
 import com.tf4.delivery.dto.request.DeliveryRouteLegPatchRequestDto;
+import com.tf4.delivery.dto.response.DeliveryResponseDto;
 import com.tf4.delivery.dto.response.DeliveryRouteLegCreateResponseDto;
 import com.tf4.delivery.dto.response.DeliveryRouteLegResponseDto;
+import com.tf4.delivery.entity.Delivery;
+import com.tf4.delivery.entity.DeliveryAgent;
 import com.tf4.delivery.entity.DeliveryRouteLeg;
+import com.tf4.delivery.entity.LogisticsManage;
+import com.tf4.delivery.repository.feign.hub.HubFeignClient;
+import com.tf4.delivery.repository.feign.hub.response.HubFindInfoResponseDto;
+import com.tf4.delivery.repository.jpa.DeliveryAgentRepository;
+import com.tf4.delivery.repository.jpa.DeliveryRepository;
 import com.tf4.delivery.repository.jpa.DeliveryRouteLegRepository;
+import com.tf4.delivery.repository.jpa.LogisticsManageRepository;
 import com.tf4.delivery.spec.DeliveryRouteLegSpecifications;
 import jakarta.ws.rs.NotFoundException;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +26,7 @@ import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigInteger;
 import java.util.UUID;
 
 @Service
@@ -23,8 +34,12 @@ import java.util.UUID;
 public class DeliveryRouteLegService {
 
     private final DeliveryRouteLegRepository deliveryRouteLegRepository;
+    private final LogisticsManageRepository logisticsManageRepository;
+    private final DeliveryAgentRepository deliveryAgentRepository;
 //    private final HubClient hubClient;
 //    private final UserClient userClient;
+    private final HubFeignClient hubFeignClient;
+    private final DeliveryRepository deliveryRepository;
 
     public Page<DeliveryRouteLegResponseDto> searchDeliveryRouteLeg(String q, Pageable pageable){
 
@@ -47,41 +62,67 @@ public class DeliveryRouteLegService {
         return DeliveryRouteLegResponseDto.from(deliveryRouteLeg);
     }
 
-
     @Transactional
     public DeliveryRouteLegCreateResponseDto createDeliveryRouteLeg(DeliveryRouteLegCreateRequestDto requestDto){
 
-        // 허브한테 출발허브 - 도착허브 => 예상 거리, 예상 소요시간  달라 해야함
+        UUID arrivalHubId = requestDto.getArrivalHubId();
+        UUID departureHubId = requestDto.getDepartureHubId();
+
+        HubFindInfoResponseDto hub = hubFeignClient.findHubIDByHubId(arrivalHubId, departureHubId);
+        Long estimatedTimeMin = hub.getTransitTime();
+        Double estimatedDistanceKm = hub.getDistance();
+
+        UUID hubDeliveryAgentId = pickNextHubAgentByPointer();
+
+
+        Delivery parent = deliveryRepository.findById(requestDto.getDeliveryId())
+                .orElseThrow(() -> new NotFoundException("배송을 찾을 수 없습니다."));
+        parent.setStatus("HUB_TO_HUB_IN_TRANSIT");
+
 
         DeliveryRouteLeg deliveryRouteLeg = DeliveryRouteLeg.builder()
+                .deliveryId(requestDto.getDeliveryId())
                 .departureHubId(requestDto.getDepartureHubId())
                 .arrivalHubId(requestDto.getArrivalHubId())
-                .estimatedDistanceKm(requestDto.getEstimatedDistanceKm())
-                .estimatedTimeMin(requestDto.getEstimatedTimeMin())
-                .actualDistanceKm(requestDto.getActualDistanceKm())
-                .actualTimeMin(requestDto.getActualTimeMin())
-                .status("WAITING_AT_HUB")
-                .hubDeliveryAgentId(requestDto.getHubDeliveryAgentId())
+                .estimatedDistanceKm(estimatedDistanceKm)
+                .estimatedTimeMin(estimatedTimeMin)
+                .actualDistanceKm(null)
+                .actualTimeMin(null)
+                .status("HUB_TO_HUB_IN_TRANSIT")
+                .hubDeliveryAgentId(hubDeliveryAgentId)
                 .build();
-
-        // 주문 ID 가져와서 할당
-
-        // 공급 업체 ID로 업체 테이블에서
-        // 허브 ID 가져와서 출발 허브 ID에 할당
-
-        // 수령 업체 ID 로 업체 테이블에서
-        // 사용자 ID 가져와서 업체 관리자(수령인)에 할당
-        // 수령 업체 주소 가져와서 업체 주소에 할당
-        // 허브 ID 가져와서 목적지 허브에 할당
-
-        // 수령인 ID를 통해서 수령인 Slack Id랑 전화번호 가져오기
-        // 강혁님한테 혹시 전화번호 왜 지우라고 한건지 다 여쭤보기 배송테이블에서
-
-        // 업체 배송 담당자 할당
 
         DeliveryRouteLeg savedDelivery = deliveryRouteLegRepository.save(deliveryRouteLeg);
 
         return new DeliveryRouteLegCreateResponseDto(savedDelivery.getDeliveryId());
+    }
+
+    @Transactional
+    public UUID pickNextHubAgentByPointer() {
+        // 전역 1행 잠금 & 초기화
+        if (logisticsManageRepository.count()==0) {
+            LogisticsManage lm = logisticsManageRepository.save(
+                    LogisticsManage.builder()
+                            .id(1L)  // 전역 1행 전략 =>  상수 P
+                            .currentAgentSeq(BigInteger.ZERO)
+                            .build());
+        }
+
+        LogisticsManage lm = logisticsManageRepository.findById(1L).orElseThrow(() -> new NotFoundException(""));
+
+        BigInteger cur = lm.getCurrentAgentSeq() == null ? BigInteger.ZERO : lm.getCurrentAgentSeq();
+        // 1) seq > cur 중 최솟값
+        DeliveryAgent agent = deliveryAgentRepository
+                .findFirstByDeliveryTypeAndDeletedAtIsNullAndDeliverySeqGreaterThanOrderByDeliverySeqAsc(
+                        "HUB", cur)
+                // 2) 없으면 wrap: 전체 중 최솟값
+                .orElseGet(() -> deliveryAgentRepository
+                        .findFirstByDeliveryTypeAndDeletedAtIsNullOrderByDeliverySeqAsc("HUB")
+                        .orElseThrow(() -> new IllegalStateException("가용 HUB 담당자 없음")));
+        // 포인터를 선택된 담당자의 seq로 이동
+        lm.setCurrentAgentSeq(agent.getDeliverySeq());
+        logisticsManageRepository.save(lm);
+        return agent.getUserId(); // 이 ID를 허브 배송담당자 ID로 사용
     }
 
     @Transactional
@@ -92,6 +133,11 @@ public class DeliveryRouteLegService {
 
         if (requestDto.getStatus() != null) {
             deliveryRouteLeg.setStatus(requestDto.getStatus());
+
+            Delivery parent = deliveryRepository.findById(deliveryRouteLeg.getDeliveryId())
+                    .orElseThrow(() -> new NotFoundException("배송을 찾을 수 없습니다."));
+            parent.setStatus(requestDto.getStatus());
+
         }
 
         // 출발/도착 허브

--- a/src/main/java/com/tf4/delivery/service/DeliveryService.java
+++ b/src/main/java/com/tf4/delivery/service/DeliveryService.java
@@ -2,6 +2,7 @@ package com.tf4.delivery.service;
 
 import com.tf4.delivery.dto.request.DeliveryCreateRequestDto;
 import com.tf4.delivery.dto.request.DeliveryPatchRequestDto;
+import com.tf4.delivery.dto.request.DeliveryRouteLegCreateRequestDto;
 import com.tf4.delivery.dto.response.DeliveryCreateResponseDto;
 import com.tf4.delivery.dto.response.DeliveryResponseDto;
 import com.tf4.delivery.entity.Delivery;
@@ -20,6 +21,9 @@ import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 @Service
@@ -31,19 +35,25 @@ public class DeliveryService {
 //    private final UserClient userClient;
     private final CompanyFeignClient companyFeignClient;
     private final AuthFeignClient authFeignClient;
+    private final DeliveryRouteLegService deliveryRouteLegService;
 
-    public Page<DeliveryResponseDto> searchDeliveries(String q, Pageable pageable){
+    public Page<DeliveryResponseDto> searchDeliveries(
+            String q, String status, LocalDate date, Pageable pageable
+    ) {
+        List<Specification<Delivery>> specs = new ArrayList<>();
 
-        Pageable capped = PageRequest.of(
-                pageable.getPageNumber(),
-                Math.min(pageable.getPageSize(), 100),
-                pageable.getSort()
-        );
+        if (q != null && !q.isBlank()) {
+            specs.add(DeliverySpecifications.searchAllFields(q));
+        }
+        // filter(status, date)는 내부에서 notDeleted + createdAt 날짜 + status를 AND로 묶음
+        specs.add(DeliverySpecifications.filter(status, date));
 
-        Specification<Delivery> spec = DeliverySpecifications.searchAllFields(q);
+        Specification<Delivery> spec = Specification.allOf(specs);
 
-        return deliveryRepository.findAll(spec, capped).map(DeliveryResponseDto::from);
+        Page<Delivery> page = deliveryRepository.findAll(spec, pageable);
+        return page.map(DeliveryResponseDto::from);
     }
+
 
     public DeliveryResponseDto getDelivery(UUID deliveryId){
         Delivery delivery = deliveryRepository.findById(deliveryId)
@@ -54,9 +64,6 @@ public class DeliveryService {
 
     @Transactional
     public DeliveryCreateResponseDto createDelivery(DeliveryCreateRequestDto requestDto){
-
-        // [order쪽에서 받아 올 수 있는 것]
-        // 주문 Id
 
         // 공급 업체 ID -> 출발 허브 id,
         CompanyFindInfoResponseDto supplyCompany = companyFeignClient.findCompanyInfoByCompanyId(requestDto.getSupplyCompanyId());
@@ -73,7 +80,6 @@ public class DeliveryService {
         AuthFindInfoResponseDto receivedUser = authFeignClient.getUserInfo(userId);
         String slackId = receivedUser.getSlackId();
 
-
         // 업체 배송 담당자 = Null
         Delivery delivery = Delivery.builder()
                 .departureHubId(departmentHubId)
@@ -87,6 +93,14 @@ public class DeliveryService {
                 .build();
 
         Delivery savedDelivery = deliveryRepository.save(delivery);
+
+        DeliveryRouteLegCreateRequestDto legDto = DeliveryRouteLegCreateRequestDto.builder()
+                .deliveryId(savedDelivery.getDeliveryId())
+                .departureHubId(savedDelivery.getDepartureHubId())
+                .arrivalHubId(savedDelivery.getArrivalHubId())
+                .build();
+
+        deliveryRouteLegService.createDeliveryRouteLeg(legDto);
 
         return new DeliveryCreateResponseDto(savedDelivery.getDeliveryId());
     }

--- a/src/main/java/com/tf4/delivery/spec/DeliverySpecifications.java
+++ b/src/main/java/com/tf4/delivery/spec/DeliverySpecifications.java
@@ -5,6 +5,8 @@ import jakarta.persistence.criteria.Expression;
 import jakarta.persistence.criteria.Predicate;
 import org.springframework.data.jpa.domain.Specification;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -101,7 +103,29 @@ public class DeliverySpecifications {
             //     return cb.disjunction(); // 결과 0건. 필요 시 400 에러로 바꿔도 됨.
             // }
 
-            return cb.and(notDeleted, cb.or(orList.toArray(new Predicate[0])));
+            //return cb.and(notDeleted, cb.or(orList.toArray(new Predicate[0])));
+            return notDeleted;
+        };
+    }
+
+    public static Specification<Delivery> filter(String status, LocalDate date) {
+        return (root, query, cb) -> {
+            List<Predicate> ands = new ArrayList<>();
+            ands.add(cb.isNull(root.get("deletedAt"))); // not-deleted
+
+            if (status != null && !status.isBlank()) {
+                ands.add(cb.equal(cb.lower(root.get("status")), status.toLowerCase()));
+                // enum이면: ands.add(cb.equal(root.get("status"), DeliveryStatus.valueOf(status)));
+            }
+
+            if (date != null) {
+                LocalDateTime start = date.atStartOfDay();
+                LocalDateTime endEx = date.plusDays(1).atStartOfDay();
+                ands.add(cb.greaterThanOrEqualTo(root.get("createdAt"), start));
+                ands.add(cb.lessThan(root.get("createdAt"), endEx));
+            }
+
+            return cb.and(ands.toArray(new Predicate[0]));
         };
     }
 


### PR DESCRIPTION
## 작업 내용 

- 허브 간 **배송 담당자 할당 로직** 도입
    - 엔티티/DTO 추가(예: `DeliveryAgent`, `LogisticsManage` 등) 및 포인터 기반 라운드로빈 선택
- **JPQL 업데이트 쿼리/조회** 추가(담당자/포인터 선택, 상태 변경 등)
- **검색 조건 복합(AND) 필터** 지원: `status` + `date(createdAt)` 조합 및 단일 조건 유지
- **배송 생성 후 허브 경로(DeliveryRouteLeg) 자동 생성**
    - 도메인 이벤트 발행 → 커밋 이후 오케스트레이터에서 경로 생성
- **허브 서비스 연동을 위한 FeignClient** 추가 및 **fallback** 구성
- **상태 동기화 로직**: 경로 상태 변경 시 **부모 Delivery** 상태도 동일 반영
- 단위 변경에 따른 **타입 교정** 및 요청 필드 **간소화**
- 빌더 사용을 위한 Lombok **어노테이션 추가**
- 필요한 **라이브러리/설정 정리(compileOnly/annotationProcessor 등)**

## 관련 이슈 
추후 이슈 연동 예정 


## 작업 상세 내용 

- 엔티티/DTO
    - 허브 담당자/순번 관리용 엔티티 및 대응 DTO 추가 (`DeliveryAgent`, `LogisticsManage`, 필요 DTO)
    - 허브 간 경로 기록 엔티티 `DeliveryRouteLeg` 관련 DTO 정비(생성/조회/수정)
- JPQL & Repository
    - 허브 담당자 **다음 순번 선택**: `findFirstBy...DeliverySeqGreaterThanOrderByDeliverySeqAsc` + wrap-around 쿼리
    - 상태 변경 벌크 업데이트/조회 JPQL 보강(필요한 곳)
- 검색 스펙
    - `DeliverySpecifications.searchAllFields(q)` 유지
    - `filter(status, LocalDate date)` 추가 → `Specification.allOf(...)`로 조합
    - 컨트롤러에서 `GET /deliveries?status=ARRIVED_AT_HUB&date=yyyy-MM-dd` 지원(기존 `q`와 조합 가능)
- 도메인 이벤트
    - `DeliveryCreatedEvent` 클래스 추가
    - `@TransactionalEventListener(AFTER_COMMIT)` 오케스트레이터에서 `DeliveryRouteLeg` 생성
    - 생성 시 `Delivery.status = HUB_TO_HUB_IN_TRANSIT`로 전이
- 상태 동기화
    - `PATCH /delivery-route-legs/{routeLegId}`로 경로 상태 변경 시 **부모 Delivery** 상태도 동일 업데이트
- 통신
    - `HubFeignClient` 추가(거리/예상시간 조회), **fallback** 구현
    - 허브 응답용 DTO 추가
- 타입/요청 정리
    - 시간/거리 **단위 변경**에 따른 필드 타입 교정(Long/Double 등)
    - 생성/수정 요청 DTO의 **필요 필드 최소화**
- 빌더/롬복
    - DTO에 `@Builder` 등 추가, **annotation processing 활성화** 전제

## 주의사항